### PR TITLE
Update ExportTableButton.tsx

### DIFF
--- a/src/exportable/ExportTableButton.tsx
+++ b/src/exportable/ExportTableButton.tsx
@@ -194,7 +194,7 @@ export const ExportTableButton: React.FC<ExportFieldButtonProps> = (props) => {
       </Button>
       {showColumnPicker ? (
         <Modal
-          visible={showModal}
+          open={showModal}
           onOk={(): void => handleDownloadCSV()}
           onCancel={(): void => setShowModal(false)}
           width={400}


### PR DESCRIPTION
The prop 'visible' on the Antd component (Modal) is deprecated. Changed it to the more current "open".